### PR TITLE
Removed python from travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-language: python
+language: minimal
 
 install:
-- curl -L https://deno.land/x/install/install.py | python
-- export PATH="$HOME/.deno/bin:$PATH"
+  - curl -L https://deno.land/x/install/install.sh | bash
+  - export PATH="$HOME/.deno/bin:$PATH"
 
 script:
-- deno dejs_test.ts
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	deno dejs_test.ts --allow-read

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ $ deno index.ts
 </html>
 ```
 
+## Development
+
+### Testing
+
+- Run `make test`.
+
 ## Author
 
 syumai


### PR DESCRIPTION
## What

* Same as title.

## Why

* Because installation script has been updated not to require python.