### PR TITLE
Fixed tags after change of version numbering

### DIFF
--- a/vendor/https/deno.land/std/encoding/utf8.ts
+++ b/vendor/https/deno.land/std/encoding/utf8.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@v0.61.0/encoding/utf8.ts";
+export * from "https://deno.land/std@0.61.0/encoding/utf8.ts";

--- a/vendor/https/deno.land/std/io/bufio.ts
+++ b/vendor/https/deno.land/std/io/bufio.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@v0.61.0/io/bufio.ts";
+export * from "https://deno.land/std@0.61.0/io/bufio.ts";

--- a/vendor/https/deno.land/std/io/readers.ts
+++ b/vendor/https/deno.land/std/io/readers.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@v0.61.0/io/readers.ts";
+export * from "https://deno.land/std@0.61.0/io/readers.ts";

--- a/vendor/https/deno.land/std/testing/asserts.ts
+++ b/vendor/https/deno.land/std/testing/asserts.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@v0.61.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.61.0/testing/asserts.ts";


### PR DESCRIPTION
The imports returned a 404/403 with the 'v'. I think this is due to the new repository update of the std lib.