### PR TITLE
Escape the backslashes

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -46,6 +46,7 @@ async function include(path: string, params: Params): Promise<string> {
 
 function sanitize(str: string): string {
   return str
+    .replace(/\\/g, "\\\\")
     .replace(/\`/g, "\\\`")
     .replace(/\$/g, "\\\$")
     .replace(/\\+$/, ""); // Trim backslashes at line end. TODO: Fix this to render backslashes.


### PR DESCRIPTION
Hello,

I wanted to use a template for LaTeX, and it didn't work because of the unescaped backslashes.

This is a very small patch, which only add a sanitize rule to escape the backslashes.

All tests pass.

This should solve https://github.com/syumai/dejs/issues/58.