### PR TITLE
Remove deno deprecated APIs and handle `ReferenceError` fatal errors

### DIFF
--- a/dem.json
+++ b/dem.json
@@ -3,11 +3,11 @@
     {
       "protocol": "https",
       "path": "deno.land/std",
-      "version": "0.77.0",
+      "version": "0.102.0",
       "files": [
-        "/encoding/utf8.ts",
+        "/io/buffer.ts",
         "/io/bufio.ts",
-        "/io/readers.ts",
+        "/io/util.ts",
         "/testing/asserts.ts"
       ]
     },

--- a/mod.ts
+++ b/mod.ts
@@ -1,6 +1,5 @@
 const { open } = Deno;
 type Reader = Deno.Reader;
-import { encode } from "./vendor/https/deno.land/std/encoding/utf8.ts";
 import { BufReader } from "./vendor/https/deno.land/std/io/bufio.ts";
 import { Buffer } from "./vendor/https/deno.land/std/io/buffer.ts";
 import { readAll } from "./vendor/https/deno.land/std/io/util.ts";
@@ -32,11 +31,12 @@ interface Template {
   (params: Params): Promise<string>;
 }
 
+const encoder = new TextEncoder();
 const decoder = new TextDecoder("utf-8");
 
 class StringReader extends Buffer {
   constructor(s: string) {
-    super(encode(s).buffer);
+    super(encoder.encode(s).buffer);
   }
 }
 

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,5 +1,8 @@
 const { Buffer, copy, cwd } = Deno;
-import { assertEquals, assertThrowsAsync } from "./vendor/https/deno.land/std/testing/asserts.ts";
+import {
+  assertEquals,
+  assertThrowsAsync,
+} from "./vendor/https/deno.land/std/testing/asserts.ts";
 import { readAll } from "./vendor/https/deno.land/std/io/util.ts";
 import * as dejs from "./mod.ts";
 import escape from "./vendor/https/deno.land/x/lodash/escape.js";
@@ -14,7 +17,7 @@ const decoder = new TextDecoder("utf-8");
     //deno-lint-ignore no-explicit-any
     param?: any;
     expected: string;
-    error?: { new():Error };
+    error?: { new (): Error };
   }
 
   const testCases: Array<testCase> = [
@@ -111,8 +114,8 @@ const decoder = new TextDecoder("utf-8");
       body: "<%= unknown %>",
       param: "",
       expected: "unknown is not defined",
-      error:ReferenceError,
-    }
+      error: ReferenceError,
+    },
   ];
 
   for (const tc of testCases) {
@@ -121,7 +124,11 @@ const decoder = new TextDecoder("utf-8");
       fn: async () => {
         const buf = new Buffer();
         if (tc.error) {
-          assertThrowsAsync(() => dejs.render(tc.body, { param: tc.param }), tc.error, tc.expected);
+          assertThrowsAsync(
+            () => dejs.render(tc.body, { param: tc.param }),
+            tc.error,
+            tc.expected,
+          );
           return;
         }
         await copy(await dejs.render(tc.body, { param: tc.param }), buf);

--- a/mod_test.ts
+++ b/mod_test.ts
@@ -1,5 +1,6 @@
 const { Buffer, copy, cwd } = Deno;
-import { assertEquals } from "./vendor/https/deno.land/std/testing/asserts.ts";
+import { assertEquals, assertThrowsAsync } from "./vendor/https/deno.land/std/testing/asserts.ts";
+import { readAll } from "./vendor/https/deno.land/std/io/util.ts";
 import * as dejs from "./mod.ts";
 import escape from "./vendor/https/deno.land/x/lodash/escape.js";
 
@@ -10,8 +11,10 @@ const decoder = new TextDecoder("utf-8");
   interface testCase {
     name: string;
     body: string;
+    //deno-lint-ignore no-explicit-any
     param?: any;
     expected: string;
+    error?: { new():Error };
   }
 
   const testCases: Array<testCase> = [
@@ -103,6 +106,13 @@ const decoder = new TextDecoder("utf-8");
       param: "test",
       expected: "testconsole.log(`${param}`)", // Trims backslashes at line end.
     },
+    {
+      name: "Error: ReferenceError rejects promise instead of killing process",
+      body: "<%= unknown %>",
+      param: "",
+      expected: "unknown is not defined",
+      error:ReferenceError,
+    }
   ];
 
   for (const tc of testCases) {
@@ -110,8 +120,12 @@ const decoder = new TextDecoder("utf-8");
       name: tc.name,
       fn: async () => {
         const buf = new Buffer();
+        if (tc.error) {
+          assertThrowsAsync(() => dejs.render(tc.body, { param: tc.param }), tc.error, tc.expected);
+          return;
+        }
         await copy(await dejs.render(tc.body, { param: tc.param }), buf);
-        const actual = decoder.decode(await Deno.readAll(buf));
+        const actual = decoder.decode(await readAll(buf));
         assertEquals(actual, tc.expected);
       },
     });
@@ -123,6 +137,7 @@ const decoder = new TextDecoder("utf-8");
   interface testCase {
     name: string;
     fileName: string;
+    //deno-lint-ignore no-explicit-any
     param?: any;
     expected: string;
   }
@@ -157,14 +172,14 @@ const decoder = new TextDecoder("utf-8");
     Deno.test({
       name: tc.name,
       fn: async () => {
-        let buf = new Buffer();
+        const buf = new Buffer();
         await copy(
           await dejs.renderFile(`${cwd()}/testdata/${tc.fileName}.ejs`, {
             param: tc.param,
           }),
           buf,
         );
-        const actual = decoder.decode(await Deno.readAll(buf));
+        const actual = decoder.decode(await readAll(buf));
         assertEquals(actual, tc.expected);
       },
     });

--- a/vendor/https/deno.land/std/encoding/utf8.ts
+++ b/vendor/https/deno.land/std/encoding/utf8.ts
@@ -1,1 +1,0 @@
-export * from "https://deno.land/std@0.77.0/encoding/utf8.ts";

--- a/vendor/https/deno.land/std/io/buffer.ts
+++ b/vendor/https/deno.land/std/io/buffer.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.102.0/io/buffer.ts";

--- a/vendor/https/deno.land/std/io/bufio.ts
+++ b/vendor/https/deno.land/std/io/bufio.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.77.0/io/bufio.ts";
+export * from "https://deno.land/std@0.102.0/io/bufio.ts";

--- a/vendor/https/deno.land/std/io/readers.ts
+++ b/vendor/https/deno.land/std/io/readers.ts
@@ -1,1 +1,0 @@
-export * from "https://deno.land/std@0.77.0/io/readers.ts";

--- a/vendor/https/deno.land/std/io/util.ts
+++ b/vendor/https/deno.land/std/io/util.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.102.0/io/util.ts";

--- a/vendor/https/deno.land/std/testing/asserts.ts
+++ b/vendor/https/deno.land/std/testing/asserts.ts
@@ -1,1 +1,1 @@
-export * from "https://deno.land/std@0.77.0/testing/asserts.ts";
+export * from "https://deno.land/std@0.102.0/testing/asserts.ts";


### PR DESCRIPTION
Closes #70

This patch forces the evaled code to reject using the upper scope promise to make it actually possible to handle `ReferenceError` when an unknown params is passed

```diff
-     await new Promise((resolve) => {
+     await new Promise((resolve, reject) => {
      const args = {
        ...params,
        include,
        $$OUTPUT: output,
        $$FINISHED: resolve,
+       $$ERROR: reject,
        $$ESCAPE: escape,
      };
      const src = `(async() => {
-       ${script}
+       try { ${script} } catch (error) { $$ERROR(error) }
        $$FINISHED();
      })();`;
```

I added a revelant test case and made minor changes to make the current linter pass (mostly moving out deprecated deno api that were moved to std) 